### PR TITLE
Remove all pixel and percentage decimal values from CSS

### DIFF
--- a/frontend/src/components/Buttons/HamburgerMenu/HamburgerMenu.js
+++ b/frontend/src/components/Buttons/HamburgerMenu/HamburgerMenu.js
@@ -15,8 +15,8 @@ const HamburgerMenuButton = styled.button`
   background-size: cover;
   background-color: transparent;
   border: 0;
-  width: 25.41px;
-  height: 25.41px;
+  width: 25px;
+  height: 25px;
 `;
 
 function HamburgerMenu({ isActive, onClick: handleClick }) {


### PR DESCRIPTION
Only one file was found with decimal pixel values. Performed a regex search on the project `/\d\.\d/` and `/\.\d/` to find all pixel values, then parsed through each one to identify any that needed adjusting. This file was the only culprit.

Closes #76 .