### PR TITLE
bugfix/97-blurry-svg

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -44,7 +44,7 @@
   transform: rotate(11deg) translate(-450px, calc(-1250px + (2vh * 30)));
   background-repeat: repeat-x;
   height: 5000px;
-  width: 3890px;
+  width: 4200px;
 }
 
 @media (min-width: 2470px) {


### PR DESCRIPTION
_**What it does**_

- Fixes blurry SVG background when zooming in by using `background-size: contain` on the SVG background
- Adjusts width of SVG to keep it in a similar position as before

_**What to look out for**_

- Only tested on Chrome, not Mac

-------------------------------

**Comparison Shots** (first image is **Before**, second one is **After**)

_500% Zoom_
<p float="left">
  <img src="https://user-images.githubusercontent.com/37381007/110217431-08000780-7e82-11eb-99cf-d4e7b5fd6481.png" height="200" />
  <img src="https://user-images.githubusercontent.com/37381007/110217436-13ebc980-7e82-11eb-8634-0b1acc0cddf9.png" height="200" /> 
</p>

_Mobile view_
<p float="left">
  <img src="https://user-images.githubusercontent.com/37381007/110217492-3da4f080-7e82-11eb-816a-58fd3bf5833f.png" height="400" />
  <img src="https://user-images.githubusercontent.com/37381007/110217501-4b5a7600-7e82-11eb-91c5-66a8f5660c0b.png" height="400" /> 
</p>

_Fullscreen view_
<p float="left">
  <img src="https://user-images.githubusercontent.com/37381007/110217524-69c07180-7e82-11eb-88a4-39ca8d56224f.png" height="200" />
  <img src="https://user-images.githubusercontent.com/37381007/110217523-6927db00-7e82-11eb-9f36-ff2b5a70373c.png" height="200" /> 
</p>