### PR TITLE
Add event listener for escape keypress and associated test

### DIFF
--- a/frontend/src/components/Modal/Modal.js
+++ b/frontend/src/components/Modal/Modal.js
@@ -28,12 +28,20 @@ export default function Modal({ children, onClickOutside }) {
       }
     };
 
+    const handleKeyPress = (event) => {
+      if (event.key === 'Escape') {
+        onClickOutside();
+      }
+    };
+
     document.addEventListener('mousedown', handleClickOutside);
     document.addEventListener('touchstart', handleClickOutside);
+    document.addEventListener('keydown', handleKeyPress);
 
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('touchstart', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyPress);
     };
   }, []);
 

--- a/frontend/src/components/Modal/Modal.spec.js
+++ b/frontend/src/components/Modal/Modal.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { render, cleanup, screen } from '@testing-library/react';
+import { render, cleanup, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import renderer from 'react-test-renderer';
 import Modal from './Modal';
@@ -95,6 +95,23 @@ describe('Modal', () => {
       userEvent.click(screen.getByTestId('modal-child'));
       expect(handleChildClick).toHaveBeenCalled();
       expect(handleClick).not.toHaveBeenCalled();
+    });
+
+    it('fires onClickOutside when the escape key is press', () => {
+      expect(handleClick).not.toHaveBeenCalled();
+
+      render(
+        <Modal onClickOutside={handleClick}>
+          <div>Test</div>
+        </Modal>,
+      );
+
+      fireEvent.keyDown(screen.getByText('Test'), {
+        key: 'Escape',
+        code: 'Escape',
+      });
+
+      expect(handleClick).toHaveBeenCalledTimes(1);
     });
   });
   // ----------------------------------------------------------------------------


### PR DESCRIPTION
## Adds key press accessibility for modal

The escape key now closes the modal.

Close #103 