### PR TITLE
Refactor/100 player join screen

### DIFF
--- a/frontend/src/__snapshots__/App.spec.js.snap
+++ b/frontend/src/__snapshots__/App.spec.js.snap
@@ -778,7 +778,7 @@ exports[`App snapshots should show the player screen after user has clicked the 
   display: grid;
   height: 100%;
   background-color: var(--primary-background-color);
-  grid-template-rows: 130px 1fr 140px;
+  grid-template-rows: 130px 1fr auto;
   grid-template-columns: 1fr;
 }
 
@@ -982,7 +982,7 @@ exports[`App snapshots should show the player screen after user has clicked the 
 
 @media screen and (min-width:786px) {
   .c0 {
-    grid-template-rows: 180px 1fr 120px;
+    grid-template-rows: 180px 1fr auto;
   }
 
   .c0 .player-join-form-container {
@@ -1131,7 +1131,7 @@ exports[`App snapshots should show the player screen after user has clicked the 
 
 @media screen and (min-height:321px) and (max-height:375px) {
   .c0 {
-    grid-template-rows: 60px 1fr 140px;
+    grid-template-rows: 60px 1fr auto;
   }
 
   .c0 .player-join-form-container {
@@ -1161,7 +1161,7 @@ exports[`App snapshots should show the player screen after user has clicked the 
 
 @media screen and (max-height:567px) {
   .c0 {
-    grid-template-rows: 60px 1fr 140px;
+    grid-template-rows: 60px 1fr auto;
   }
 
   .c0 .player-join-form {

--- a/frontend/src/components/screenControllers/PlayerScreenController/__snapshots__/PlayerScreenController.spec.js.snap
+++ b/frontend/src/components/screenControllers/PlayerScreenController/__snapshots__/PlayerScreenController.spec.js.snap
@@ -65,7 +65,7 @@ exports[`Player screen controller render renders correctly 1`] = `
   display: grid;
   height: 100%;
   background-color: var(--primary-background-color);
-  grid-template-rows: 130px 1fr 140px;
+  grid-template-rows: 130px 1fr auto;
   grid-template-columns: 1fr;
 }
 
@@ -249,7 +249,7 @@ exports[`Player screen controller render renders correctly 1`] = `
 
 @media screen and (min-width:786px) {
   .c0 {
-    grid-template-rows: 180px 1fr 120px;
+    grid-template-rows: 180px 1fr auto;
   }
 
   .c0 .player-join-form-container {
@@ -398,7 +398,7 @@ exports[`Player screen controller render renders correctly 1`] = `
 
 @media screen and (min-height:321px) and (max-height:375px) {
   .c0 {
-    grid-template-rows: 60px 1fr 140px;
+    grid-template-rows: 60px 1fr auto;
   }
 
   .c0 .player-join-form-container {
@@ -428,7 +428,7 @@ exports[`Player screen controller render renders correctly 1`] = `
 
 @media screen and (max-height:567px) {
   .c0 {
-    grid-template-rows: 60px 1fr 140px;
+    grid-template-rows: 60px 1fr auto;
   }
 
   .c0 .player-join-form {

--- a/frontend/src/components/screens/PlayerJoinScreen/PlayerJoinScreen.js
+++ b/frontend/src/components/screens/PlayerJoinScreen/PlayerJoinScreen.js
@@ -15,7 +15,7 @@ const PlayerJoinContainer = styled.div`
   display: grid;
   height: 100%;
   background-color: var(--primary-background-color);
-  grid-template-rows: 130px 1fr 140px;
+  grid-template-rows: 130px 1fr auto;
   grid-template-columns: 1fr;
 
   main {
@@ -99,7 +99,7 @@ const PlayerJoinContainer = styled.div`
 
   @media screen and (min-width: 786px) {
     // header, main, footer
-    grid-template-rows: 180px 1fr 120px;
+    grid-template-rows: 180px 1fr auto;
 
     .player-join-form-container {
       max-width: 800px;
@@ -211,7 +211,7 @@ const PlayerJoinContainer = styled.div`
 
   // medium mobile landscape orientation
   @media screen and (min-height: 321px) and (max-height: 375px) {
-    grid-template-rows: 60px 1fr 140px;
+    grid-template-rows: 60px 1fr auto;
 
     .player-join-form-container {
       margin-top: -20px;
@@ -233,7 +233,6 @@ const PlayerJoinContainer = styled.div`
 
     .player-join-form {
       grid-template-rows: 60px 60px 1fr;
-      /* grid-template-rows: 50px 40px 1fr; */
     }
 
     input {
@@ -244,7 +243,7 @@ const PlayerJoinContainer = styled.div`
   // all mobile size landscape orientation
   @media screen and (max-height: 567px) {
     // header, main, footer
-    grid-template-rows: 60px 1fr 140px;
+    grid-template-rows: 60px 1fr auto;
 
     .player-join-form {
       grid-template-columns: 52% 48%;

--- a/frontend/src/components/screens/PlayerJoinScreen/__snapshots__/PlayerJoinScreen.spec.js.snap
+++ b/frontend/src/components/screens/PlayerJoinScreen/__snapshots__/PlayerJoinScreen.spec.js.snap
@@ -65,7 +65,7 @@ exports[`PlayerJoin snapshot matches 1`] = `
   display: grid;
   height: 100%;
   background-color: var(--primary-background-color);
-  grid-template-rows: 130px 1fr 140px;
+  grid-template-rows: 130px 1fr auto;
   grid-template-columns: 1fr;
 }
 
@@ -249,7 +249,7 @@ exports[`PlayerJoin snapshot matches 1`] = `
 
 @media screen and (min-width:786px) {
   .c0 {
-    grid-template-rows: 180px 1fr 120px;
+    grid-template-rows: 180px 1fr auto;
   }
 
   .c0 .player-join-form-container {
@@ -398,7 +398,7 @@ exports[`PlayerJoin snapshot matches 1`] = `
 
 @media screen and (min-height:321px) and (max-height:375px) {
   .c0 {
-    grid-template-rows: 60px 1fr 140px;
+    grid-template-rows: 60px 1fr auto;
   }
 
   .c0 .player-join-form-container {
@@ -428,7 +428,7 @@ exports[`PlayerJoin snapshot matches 1`] = `
 
 @media screen and (max-height:567px) {
   .c0 {
-    grid-template-rows: 60px 1fr 140px;
+    grid-template-rows: 60px 1fr auto;
   }
 
   .c0 .player-join-form {


### PR DESCRIPTION
**Description**
Previously, the CSS in PlayerJoinScreen was written desktop first. These changes refactor the CSS to use mobile first practices. Additionally, these changes fix mobile landscape orientation bugs on the PlayerJoinScreen. 

Closes #100 

Note: Ideally, I'd like to make changes also to the shared Footer component but wanted to work on that _after_ getting feedback on this.

**Screenshots**  
iPhone 5 (small mobile), landscape orientation
<img width="591" alt="Screen Shot 2021-03-23 at 1 33 08 PM" src="https://user-images.githubusercontent.com/35714338/112215840-12d6ce00-8bde-11eb-9d51-3bb801044faf.png">

iPhone 6/7/8 plus (large mobile), landscape orientation
<img width="782" alt="Screen Shot 2021-03-23 at 1 33 32 PM" src="https://user-images.githubusercontent.com/35714338/112215958-36017d80-8bde-11eb-9cf5-aa168184a44e.png">

_these screenshots are taken with the footer component disabled because it still needs some work_

I used `(max-height: )` in my media queries because tallest (height) mobile screen we support is iPhone 5 @ 568px, therefore even the largest mobile device widths are still shorter (height) when in landscape - so if the height is less than 568px, it should be safe to assume that the device is in landscape orientation. I avoided using `(orientation: landscape)` in my media queries for the following reason: 

"Note: This value does not correspond to actual device orientation. Opening the soft keyboard on most devices in portrait orientation will cause the viewport to become wider than it is tall, thereby causing the browser to use landscape styles instead of portrait"

**Testing**
For the time being, I'd recommend disabling the footer to better visualize what landscape orientations will look like. Due to all the snapshot changes, it looks like there was a lot changed but it's really only the PlayerJoinScreen CSS.