### PR TITLE
Fix PlayerKicker to display names upcased to match other components

### DIFF
--- a/frontend/src/components/HostSettingsMenu/SettingsSubComponents/PlayerKicker.js
+++ b/frontend/src/components/HostSettingsMenu/SettingsSubComponents/PlayerKicker.js
@@ -22,12 +22,12 @@ function PlayerKicker({ accordionState, onClickActions }) {
   // this variable is needed for the OptionList API; it needs the player names
   // in an array of strings
   const playerList = playerIDs
-    .map((playerId) => players[playerId].name)
+    .map((playerId) => players[playerId].name.toUpperCase())
     .sort((a, b) => b > a);
 
   function kickPlayer(playerName) {
     const targetPlayer = playerIDs.find(
-      (playerId) => players[playerId].name === playerName,
+      (playerId) => players[playerId].name.toUpperCase() === playerName,
     );
 
     dispatch({

--- a/frontend/src/components/HostSettingsMenu/SettingsSubComponents/PlayerKicker.spec.js
+++ b/frontend/src/components/HostSettingsMenu/SettingsSubComponents/PlayerKicker.spec.js
@@ -52,6 +52,35 @@ describe('PlayerKicker', () => {
         .toJSON();
       expect(tree).toMatchSnapshot();
     });
+
+    it('upcases player names before passing them to be rendered', () => {
+      const state = {
+        players: {
+          player1: {
+            name: 'foo',
+            submittedCards: [],
+          },
+        },
+        playerIDs: ['player1'],
+      };
+      const dispatch = jest.fn();
+
+      render(
+        <HostContext.Provider value={{ state, dispatch }}>
+          <PlayerKicker
+            accordionState="open"
+            onClickActions={{
+              open: () => {},
+              enabled: () => {},
+              disabled: () => {},
+            }}
+          />
+        </HostContext.Provider>,
+      );
+
+      expect(screen.queryByText('foo')).not.toBeInTheDocument();
+      expect(screen.getByText('FOO')).toBeInTheDocument();
+    });
   });
 
   describe('functionality', () => {


### PR DESCRIPTION
Add a test to PlayerKicker to verify it is fixed.

#### 0. Make sure your issue is linked:
<!-- "closes: #issueNum". See here: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
N/A

#### 1. Purpose:
<!-- Give a description of what your component or submission is supposed to do/accomplish. -->
PlayerKicker names aren't upcased but the lobby list and name entering upcase names, this fixes PlayerKicker to match their style.


#### 2. Implementation:
<!-- Brief overview of your solution. -->
Upcase the player names before passing them to OptionList to be rendered, and upcase player names when finding the playerId to kick.


#### 3. Possible Issues:
<!-- Anything you are unsure of, specifically want others to test. -->



#### 4. How to Test:
<!-- List all steps from pulling your branch, list any files that need to be edited and what specifically needs to be added/removed(include line #), and how to deploy it. -->
0. start app backend then frontend
1. open a window as a host and a window to join
2. join the lobby using a name with lowercase letters
3. click the hamburger menu
4. click the kick player button
5. verify that your name is appearing in fully uppercase

#### 5. Cleanup
- [x] I've added all TODOs needed
- [x] I've removed all un-needed comments
- [x] I've updated the snapshot tests and checked to make sure they're accurate if they changed
- [x] I've removed all un-nessessary `console.log`s
