### PR TITLE
Send state to reducer middlwares

### DIFF
--- a/frontend/src/contexts/HostContext/hostReducerMiddleware.js
+++ b/frontend/src/contexts/HostContext/hostReducerMiddleware.js
@@ -36,7 +36,6 @@ function sendKickPlayerMessage(payload) {
 }
 
 export default async function hostReducerMiddleware(
-  state,
   dispatch,
   { type, payload },
 ) {

--- a/frontend/src/contexts/HostContext/hostReducerMiddleware.spec.js
+++ b/frontend/src/contexts/HostContext/hostReducerMiddleware.spec.js
@@ -10,9 +10,8 @@ jest.mock('../../socket/socket', () => ({
 describe('hostReducerMiddleware', () => {
   it('calls the given dispatch with the given type & payload object', () => {
     const dispatch = jest.fn();
-    const state = {};
 
-    hostReducerMiddleware(state, dispatch, {
+    hostReducerMiddleware(dispatch, {
       type: 'FOO',
       payload: { bar: 'bash' },
     });
@@ -23,11 +22,10 @@ describe('hostReducerMiddleware', () => {
   describe('CLOSE_GAME', () => {
     it("calls socketInstance's closeSocket() function once", () => {
       const dispatch = jest.fn();
-      const state = {};
 
       expect(socketInstance.closeSocket).not.toHaveBeenCalled();
 
-      hostReducerMiddleware(state, dispatch, {
+      hostReducerMiddleware(dispatch, {
         type: 'CLOSE_GAME',
         payload: {},
       });
@@ -39,9 +37,8 @@ describe('hostReducerMiddleware', () => {
   describe('CREATE_LOBBY', () => {
     it("calls socketInstance's createLobby() function once", () => {
       const dispatch = jest.fn();
-      const state = {};
 
-      hostReducerMiddleware(state, dispatch, {
+      hostReducerMiddleware(dispatch, {
         type: 'CREATE_LOBBY',
         payload: {},
       });
@@ -53,9 +50,8 @@ describe('hostReducerMiddleware', () => {
   describe('KICK_PLAYER', () => {
     it("calls socketInstance's sendMessage with a player kick message object", () => {
       const dispatch = jest.fn();
-      const state = {};
 
-      hostReducerMiddleware(state, dispatch, {
+      hostReducerMiddleware(dispatch, {
         type: 'KICK_PLAYER',
         payload: { playerId: 'example-player-id' },
       });
@@ -76,9 +72,8 @@ describe('hostReducerMiddleware', () => {
   describe('PLAYER_CONNECTED', () => {
     it("calls socketInstance's sendMessage with a default welcome message object", () => {
       const dispatch = jest.fn();
-      const state = {};
 
-      hostReducerMiddleware(state, dispatch, {
+      hostReducerMiddleware(dispatch, {
         type: 'PLAYER_CONNECTED',
         payload: { playerId: 'example-player-id' },
       });

--- a/frontend/src/contexts/useReducerMiddleware.js
+++ b/frontend/src/contexts/useReducerMiddleware.js
@@ -6,11 +6,10 @@ export default function useReducerMiddleware(
   initialState,
 ) {
   const [state, dispatch] = useReducer(reducer, initialState);
-  console.log('useReducerMiddleware: ', state);
-  const asyncDispatcher = async ({ type, payload }) => {
-    console.log('async dispatch: ', state);
-    await reducerMiddleware(state, dispatch, { type, payload });
-  };
+
+  const asyncDispatcher = ({ type, payload }) => {
+    reducerMiddleware(dispatch, { type, payload });
+  }
 
   return [state, asyncDispatcher];
 }


### PR DESCRIPTION
Refactor useReducerMiddleware and hostReducerMiddleware to send state
when executing actions.
Update associated tests to follow new API.
Change test component state display to use .toString() in favor of
JSON.stringify().

#### 0. Make sure your issue is linked:
<!-- "closes: #issueNum". See here: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Related to #169 and #167 

#### 1. Purpose:
<!-- Give a description of what your component or submission is supposed to do/accomplish. -->

State wasn't available to the async dispatcher and needed to be passed in. This hotfix ensures that state is available to any reducer actions that need to be run in the middleware before falling through to the sync dispatch.

#### 2. Implementation:
<!-- Brief overview of your solution. -->

Refactors the parameters that hostReducerMiddleware accepts to allow for state, and rewrites tests to follow this pattern.

#### 3. Possible Issues:
<!-- Anything you are unsure of, specifically want others to test. -->

Could not test hostReducerMiddleware's state parameter yet because no switch cases use it. This will be able to be tested when #140 is merged.

#### 4. How to Test:
<!-- List all steps from pulling your branch, list any files that need to be edited and what specifically needs to be added/removed(include line #), and how to deploy it. -->
n/a

#### 5. Cleanup
- [x] I've added all TODOs needed
- [x] I've removed all un-needed comments
- [x] I've updated the snapshot tests and checked to make sure they're accurate if they changed
- [x] I've removed all un-nessessary `console.log`s
