### PR TITLE
Show lobby closed message if player hand screen is up

### DIFF
--- a/frontend/src/components/screenControllers/PlayerScreenController/PlayerScreenController.js
+++ b/frontend/src/components/screenControllers/PlayerScreenController/PlayerScreenController.js
@@ -21,6 +21,7 @@ export default function PlayerScreenController() {
     case 'submitting-cards':
     case 'cards-submitted':
     case 'waiting-for-player-card-submissions':
+    case 'lobby-closed':
       return (
         <PlayerMessageScreen bigText={message.big} smallText={message.small} />
       );

--- a/frontend/src/components/screenControllers/PlayerScreenController/PlayerScreenController.spec.js
+++ b/frontend/src/components/screenControllers/PlayerScreenController/PlayerScreenController.spec.js
@@ -151,6 +151,26 @@ describe('Player screen controller', () => {
       });
     });
 
+    describe('lobby-closed', () => {
+      it('renders PlayerMessageScreen', () => {
+        PlayerMessageScreen.mockImplementation(MockPlayerMessageScreen);
+
+        const dispatch = jest.fn();
+        const state = {
+          gameState: 'lobby-closed',
+          message: { big: '', small: '' },
+        };
+
+        render(
+          <PlayerContext.Provider value={{ state, dispatch }}>
+            <PlayerScreenController />
+          </PlayerContext.Provider>,
+        );
+
+        expect(screen.getByTestId('player-message-screen')).toBeInTheDocument();
+      });
+    });
+
     describe('select-winner', () => {
       it('renders CzarHandScreen', () => {
         CzarHandScreen.mockImplementation(MockCzarHandScreen);

--- a/frontend/src/contexts/PlayerContext/PlayerContext.js
+++ b/frontend/src/contexts/PlayerContext/PlayerContext.js
@@ -38,22 +38,18 @@ export function PlayerProvider({ children }) {
     switch (event) {
       case 'join-lobby':
         return dispatch({ type: 'JOIN_LOBBY', payload });
+
       case 'update':
         return dispatch({ type: 'UPDATE', payload });
+
       case 'error-disconnect':
         return dispatch({ type: 'ERROR_DISCONNECT', payload });
+
       case 'deal-white-cards':
         return dispatch({ type: 'RECEIVE_WHITE_CARDS', payload });
+
       case 'lobby-closed':
-        return dispatch({
-          type: 'UPDATE',
-          payload: {
-            message: {
-              big: 'The lobby has been closed',
-              small: "You don't have to go home, but you can't stay here",
-            },
-          },
-        });
+        return dispatch({ type: 'LOBBY_CLOSED' });
 
       default:
         return undefined;

--- a/frontend/src/contexts/PlayerContext/PlayerContext.spec.js
+++ b/frontend/src/contexts/PlayerContext/PlayerContext.spec.js
@@ -263,6 +263,7 @@ describe('context', () => {
         return (
           <>
             <div>
+              <div data-testid="game-state">{state.gameState}</div>
               <h1 data-testid="message-big">{state.message.big}</h1>
               <p data-testid="message-small">{state.message.small}</p>
             </div>
@@ -282,9 +283,14 @@ describe('context', () => {
         eventHandlers.message({ event: 'lobby-closed', payload: {} });
       });
 
-      expect(screen.getByTestId('message-big')).toHaveTextContent(
-        'The lobby has been closed',
+      expect(screen.getByTestId('game-state')).toHaveTextContent(
+        'lobby-closed',
       );
+
+      expect(screen.getByTestId('message-big')).toHaveTextContent(
+        'THE LOBBY HAS BEEN CLOSED',
+      );
+
       expect(screen.getByTestId('message-small')).toHaveTextContent(
         "You don't have to go home, but you can't stay here",
       );

--- a/frontend/src/contexts/PlayerContext/playerReducer.js
+++ b/frontend/src/contexts/PlayerContext/playerReducer.js
@@ -61,22 +61,42 @@ function receiveWhiteCards(state, payload) {
   };
 }
 
+function lobbyClosed(state) {
+  return {
+    ...state,
+    gameState: 'lobby-closed',
+    message: {
+      big: 'THE LOBBY HAS BEEN CLOSED',
+      small: "You don't have to go home, but you can't stay here",
+    },
+  };
+}
+
 function reducer(state, action) {
   const { type, payload } = action;
   switch (type) {
     case 'JOIN_LOBBY':
       socketInstance.joinLobby(payload.lobbyId, payload.playerName);
       return joinLobby(state);
+
     case 'UPDATE':
       return update(state, payload);
+
     case 'ERROR_DISCONNECT':
       return errorDisconnect(state);
+
     case 'SUBMIT_CARDS':
       return submitCards(state);
+
     case 'SUBMIT_WINNER':
       return submitWinner(state, payload);
+
     case 'RECEIVE_WHITE_CARDS':
       return receiveWhiteCards(state, payload);
+
+    case 'LOBBY_CLOSED':
+      return lobbyClosed(state);
+
     default:
       return { ...state };
   }

--- a/frontend/src/contexts/PlayerContext/playerReducer.spec.js
+++ b/frontend/src/contexts/PlayerContext/playerReducer.spec.js
@@ -220,4 +220,25 @@ describe('reducer', () => {
       });
     });
   });
+
+  describe('LOBBY_CLOSED', () => {
+    it('returns a copy of state with the gameState and the message set properly', () => {
+      const state = {
+        gameState: 'test state',
+        message: {
+          big: 'deal',
+          small: 'pox',
+        },
+      };
+
+      const result = reducer(state, { type: 'LOBBY_CLOSED' });
+
+      expect(result).not.toBe(state);
+      expect(result.gameState).toBe('lobby-closed');
+      expect(result.message.big).toBe('THE LOBBY HAS BEEN CLOSED');
+      expect(result.message.small).toBe(
+        "You don't have to go home, but you can't stay here",
+      );
+    });
+  });
 });


### PR DESCRIPTION
#### 0. Make sure your issue is linked:
<!-- "closes: #issueNum". See here: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Closes #213 

#### 1. Purpose:
<!-- Give a description of what your component or submission is supposed to do/accomplish. -->
Show players the lobby closed message screen if they are currently in the player hand screen, this currently doesn't happen but should.


#### 2. Implementation:
<!-- Brief overview of your solution. -->
I moved the actions taken for #203 into the player reducer and had the game state update to 'lobby-closed', then added 'lobby-closed' as a case int he PlayerScreenController switch to switch the screen to the PlayerMessageScreen.


#### 3. Possible Issues:
<!-- Anything you are unsure of, specifically want others to test. -->



#### 4. How to Test:
<!-- List all steps from pulling your branch, list any files that need to be edited and what specifically needs to be added/removed(include line #), and how to deploy it. -->

1. Switch to main and pull to update it
2. Start the application backend then frontend
3. Open one browser window/tab as the host and two as a player
4. Copy the join code and join the lobby in both of your player windows
5. Select a card pack in the host window and start the game
6. Refresh the host window to trigger a host disconnect
7. Verify that both players receive messages informing them that the lobby has been closed


#### 5. Cleanup
- [x] I've added all TODOs needed
- [x] I've removed all un-needed comments
- [x] I've updated the snapshot tests and checked to make sure they're accurate if they changed
- [x] I've removed all un-nessessary `console.log`s
