### PR TITLE
Fix console warning regarding act in GameSettings tests

### DIFF
--- a/frontend/src/components/GameSettings/GameSettings.spec.js
+++ b/frontend/src/components/GameSettings/GameSettings.spec.js
@@ -68,7 +68,7 @@ describe('GameSettings', () => {
       expect(screen.getByText('world')).toBeInTheDocument();
     });
 
-    it('displays a loading indicator while the pack names are being requested', () => {
+    it('displays a loading indicator while the pack names are being requested', async () => {
       const dispatch = jest.fn();
       const onChange = () => {};
       const options = {
@@ -87,10 +87,12 @@ describe('GameSettings', () => {
         </HostContext.Provider>,
       );
 
+      await waitFor(() => expect(window.fetch).toHaveBeenCalledTimes(1));
+
       expect(screen.getByTestId('loader')).toBeInTheDocument();
     });
 
-    it('dispatches the GET_PACKS action on mount', () => {
+    it('dispatches the GET_PACKS action on mount', async () => {
       const dispatch = jest.fn();
       const onChange = () => {};
       const options = {
@@ -104,6 +106,9 @@ describe('GameSettings', () => {
           <GameSettings onChange={onChange} options={options} />
         </HostContext.Provider>,
       );
+
+      await waitFor(() => expect(window.fetch).toHaveBeenCalledTimes(1));
+
       expect(dispatch).toHaveBeenCalledWith({ type: 'GET_PACKS', payload: {} });
     });
 


### PR DESCRIPTION
#### 0. Make sure your issue is linked:

N/A

#### 1. Purpose:

Fix the console warnings printing when running the tests for GameSettings.

#### 2. Implementation:

I identified the problem tests using git bisect and following the example in other tests from Zach I added a waitFor on the window to be fetched before the expectation in two tests.

#### 3. Possible Issues:


#### 4. How to Test:

1. Fetch this branch
2. Run all of the tests and verify that no console warning/errors are printed to the console

#### 5. Cleanup
- [x] I've added all TODOs needed
- [x] I've removed all un-needed comments
- [x] I've updated the snapshot tests and checked to make sure they're accurate if they changed
- [x] I've removed all un-nessessary `console.log`s
