### PR TITLE
Update HostWinnerScreen tests to match changes in 8e80b41

### DIFF
--- a/frontend/src/screens/HostWinnerScreen/HostWinnerScreen.spec.js
+++ b/frontend/src/screens/HostWinnerScreen/HostWinnerScreen.spec.js
@@ -186,17 +186,26 @@ describe('Host Winner Screen', () => {
       jest.advanceTimersByTime(2000);
 
       expect(dispatch).not.toHaveBeenCalledWith({
+        type: 'REMOVE_SUBMITTED_CARDS_FROM_PLAYER',
+        payload: {},
+      });
+
+      expect(dispatch).not.toHaveBeenCalledWith({
         type: 'SET_NEXT_CZAR',
         payload: {},
       });
+
       expect(dispatch).not.toHaveBeenCalledWith({
         type: 'SELECT_BLACK_CARD',
         payload: {},
       });
+
       expect(dispatch).not.toHaveBeenCalledWith({
         type: 'DEAL_WHITE_CARDS',
         payload: {},
       });
+
+      expect(dispatch).toHaveBeenCalledTimes(1);
     });
 
     it('sends next round dispatches once the setTimeout executes', () => {
@@ -209,17 +218,26 @@ describe('Host Winner Screen', () => {
       jest.advanceTimersByTime(3000);
 
       expect(dispatch).toHaveBeenCalledWith({
+        type: 'REMOVE_SUBMITTED_CARDS_FROM_PLAYER',
+        payload: {},
+      });
+
+      expect(dispatch).toHaveBeenCalledWith({
         type: 'SET_NEXT_CZAR',
         payload: {},
       });
+
       expect(dispatch).toHaveBeenCalledWith({
         type: 'SELECT_BLACK_CARD',
         payload: {},
       });
+
       expect(dispatch).toHaveBeenCalledWith({
         type: 'DEAL_WHITE_CARDS',
         payload: {},
       });
+
+      expect(dispatch).toHaveBeenCalledTimes(5);
     });
   });
 });


### PR DESCRIPTION
#### 0. Make sure your issue is linked:
<!-- "closes: #issueNum". See here: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
N/A

#### 1. Purpose:
<!-- Give a description of what your component or submission is supposed to do/accomplish. -->
Add tests for functionality added in 8e80b41 that wasn't tested. 


#### 2. Implementation:
<!-- Brief overview of your solution. -->
Add assertions for the dispatch to have been called/not to have been called where needed. I also added a count of dispatches to this test so that if in the future a dispatch is added or removed from this function the test will fail and we will know to update it. 


#### 3. Possible Issues:
<!-- Anything you are unsure of, specifically want others to test. -->



#### 4. How to Test:
<!-- List all steps from pulling your branch, list any files that need to be edited and what specifically needs to be added/removed(include line #), and how to deploy it. -->
Delete the HostWinnerScreen 'REMOVE_SUBMITTED_CARDS_FROM_PLAYER' dispatch and verify that the test fails.
Add another or remove a different dispatch and verify that the `.toHaveBeenCalledTimes` test now fails.

#### 5. Cleanup
- [x] I've added all TODOs needed
- [x] I've removed all un-needed comments
- [x] I've updated the snapshot tests and checked to make sure they're accurate if they changed
- [x] I've removed all un-nessessary `console.log`s
