### PR TITLE
Fix winner screen card undefined error

### DIFF
--- a/frontend/src/screens/HostWinnerScreen/HostWinnerScreen.js
+++ b/frontend/src/screens/HostWinnerScreen/HostWinnerScreen.js
@@ -123,8 +123,9 @@ function RightPanel() {
 
       <WhiteCardWrapper columns={winner.submittedCards.length}>
         {winner.submittedCards.map((card) => (
-          <WhiteCard key={winner.cards[card].text}>
-            {winner.cards[card].text}
+          <WhiteCard key={card}>
+            {/* When round changes, the card may become undefined temporarily resulting in an error */}
+            {winner.cards[card] && winner.cards[card].text}
           </WhiteCard>
         ))}
       </WhiteCardWrapper>


### PR DESCRIPTION
#### 0. Make sure your issue is linked:
<!-- "closes: #issueNum". See here: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Close #286 

#### 1. Purpose:
<!-- Give a description of what your component or submission is supposed to do/accomplish. -->

The game crashes if a player submits the last card in their hand and wins the round. This is due to the card being removed and that array reference temporarily becoming undefined, so any references to properties on that card throw `TypeError`s.

#### 2. Implementation:
<!-- Brief overview of your solution. -->

* Replace the "key" property on the mapped selected white cards with the card number reference itself instead of the text.
* Add a short-circuit evaluation to check if the selected card is still defined before rendering its text property.

#### 3. Possible Issues:
<!-- Anything you are unsure of, specifically want others to test. -->



#### 4. How to Test:
<!-- List all steps from pulling your branch, list any files that need to be edited and what specifically needs to be added/removed(include line #), and how to deploy it. -->

1. Pull branch
2. run front & back end
3. Open tabs
4. Play game, be sure to select the final card in a player's hand and pick it as the winner
5. Observe that the game plays as expected

#### 5. Cleanup
- [x] I've added all TODOs needed
- [x] I've removed all unneeded comments
- [x] I've updated the snapshot tests and checked to make sure they're accurate if they changed
- [x] I've removed all unnecessary `console.log`s
