### PR TITLE
Feature/176 toggle join code display

### DIFF
--- a/frontend/src/components/HostSettingsMenu/SettingsSubComponents/JoinCodeHider.js
+++ b/frontend/src/components/HostSettingsMenu/SettingsSubComponents/JoinCodeHider.js
@@ -1,27 +1,25 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import OptionButton from './OptionButton';
+import { HostContext } from '../../../contexts/HostContext/HostContext';
 
 const propTypes = {
   isEnabled: PropTypes.bool.isRequired,
   onDisabledClick: PropTypes.func.isRequired,
 };
 
-// placeholder function
-function hideJoinCode() {
-  // eslint-disable-next-line
-  console.log('PRETEND THE JOIN CODE IS HIDDEN');
-}
-
 function JoinCodeHider({ isEnabled, onDisabledClick }) {
+  const { state, dispatch } = useContext(HostContext);
+  const hidden = state.gameSettings.hideJoinCode;
+
   return (
     <OptionButton
       isEnabled={isEnabled}
-      onEnabledClick={hideJoinCode}
+      onEnabledClick={() => dispatch({ type: 'TOGGLE_JOIN_CODE_VISIBILITY' })}
       onDisabledClick={onDisabledClick}
     >
-      HIDE JOIN CODE
+      {hidden ? 'SHOW JOIN CODE' : 'HIDE JOIN CODE'}
     </OptionButton>
   );
 }

--- a/frontend/src/components/HostSettingsMenu/SettingsSubComponents/JoinCodeHider.spec.js
+++ b/frontend/src/components/HostSettingsMenu/SettingsSubComponents/JoinCodeHider.spec.js
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import renderer from 'react-test-renderer';
 
 import JoinCodeHider from './JoinCodeHider';
+import { HostContext } from '../../../contexts/HostContext/HostContext';
 
 // mock the OptionButton component that is imported into JoinCodeHider
 jest.mock(
@@ -33,24 +34,98 @@ jest.mock(
 describe('JoinCodeHider', () => {
   describe('rendering', () => {
     it('matches the snapshot', () => {
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
+
+      const dispatch = jest.fn();
+
       const tree = renderer
-        .create(<JoinCodeHider isEnabled onDisabledClick={() => {}} />)
+        .create(
+          <HostContext.Provider value={{ state, dispatch }}>
+            <JoinCodeHider isEnabled onDisabledClick={() => {}} />
+          </HostContext.Provider>,
+        )
         .toJSON();
 
       expect(tree).toMatchSnapshot();
+    });
+
+    it('says "HIDE JOIN CODE" when the hideJoinCode setting is false', () => {
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
+
+      const dispatch = jest.fn();
+
+      render(
+        <HostContext.Provider value={{ state, dispatch }}>
+          <JoinCodeHider isEnabled onDisabledClick={() => {}} />
+        </HostContext.Provider>,
+      );
+      const optionButton = screen.getByTestId('option-button');
+
+      expect(optionButton.textContent).toBe('HIDE JOIN CODE');
+    });
+
+    it('says "SHOW JOIN CODE" when the hideJoinCode setting is true', () => {
+      const state = {
+        gameSettings: {
+          hideJoinCode: true,
+        },
+      };
+
+      const dispatch = jest.fn();
+
+      render(
+        <HostContext.Provider value={{ state, dispatch }}>
+          <JoinCodeHider isEnabled onDisabledClick={() => {}} />
+        </HostContext.Provider>,
+      );
+      const optionButton = screen.getByTestId('option-button');
+
+      expect(optionButton.textContent).toBe('SHOW JOIN CODE');
     });
   });
 
   describe('functionality', () => {
     it('passes the expected text to be rendered as text in the option button', () => {
-      render(<JoinCodeHider isEnabled onDisabledClick={() => {}} />);
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
+
+      const dispatch = jest.fn();
+
+      render(
+        <HostContext.Provider value={{ state, dispatch }}>
+          <JoinCodeHider isEnabled onDisabledClick={() => {}} />
+        </HostContext.Provider>,
+      );
       const optionButton = screen.getByTestId('option-button');
 
       expect(optionButton.textContent).toBe('HIDE JOIN CODE');
     });
 
     it('passes the isEnabled prop through when false', () => {
-      render(<JoinCodeHider isEnabled={false} onDisabledClick={() => {}} />);
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
+
+      const dispatch = jest.fn();
+
+      render(
+        <HostContext.Provider value={{ state, dispatch }}>
+          <JoinCodeHider isEnabled={false} onDisabledClick={() => {}} />
+        </HostContext.Provider>,
+      );
       const optionButton = screen.getByRole('button', {
         name: 'HIDE JOIN CODE',
       });
@@ -59,7 +134,19 @@ describe('JoinCodeHider', () => {
     });
 
     it('passes the isEnabled prop through when true', () => {
-      render(<JoinCodeHider isEnabled onDisabledClick={() => {}} />);
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
+
+      const dispatch = jest.fn();
+
+      render(
+        <HostContext.Provider value={{ state, dispatch }}>
+          <JoinCodeHider isEnabled onDisabledClick={() => {}} />
+        </HostContext.Provider>,
+      );
       const optionButton = screen.getByRole('button', {
         name: 'HIDE JOIN CODE',
       });
@@ -69,48 +156,88 @@ describe('JoinCodeHider', () => {
 
     // this test and the one below it are temporary and to be replaced once functionality
     // for JoinCodeHider is actually built out
-    it('does not log to the console when an option button is enabled but not clicked', () => {
-      const consoleSpy = jest
-        .spyOn(console, 'log')
-        .mockImplementation(() => {});
+    it('does not dispatch an action when the button is not clicked', () => {
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
 
-      render(<JoinCodeHider isEnabled onDisabledClick={() => {}} />);
+      const dispatch = jest.fn();
 
-      expect(consoleSpy).not.toHaveBeenCalled();
+      render(
+        <HostContext.Provider value={{ state, dispatch }}>
+          <JoinCodeHider isEnabled onDisabledClick={() => {}} />
+        </HostContext.Provider>,
+      );
+
+      expect(dispatch).not.toHaveBeenCalled();
     });
 
-    it('logs to the console when an option button is enabled and clicked', () => {
-      const consoleSpy = jest
-        .spyOn(console, 'log')
-        .mockImplementation(() => {});
+    it('dispatches a "TOGGLE_JOIN_CODE_VISIBILITY" action when button is enabled and clicked', () => {
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
 
-      render(<JoinCodeHider isEnabled onDisabledClick={() => {}} />);
+      const dispatch = jest.fn();
+
+      render(
+        <HostContext.Provider value={{ state, dispatch }}>
+          <JoinCodeHider isEnabled onDisabledClick={() => {}} />
+        </HostContext.Provider>,
+      );
       userEvent.click(screen.getByRole('button', { name: 'HIDE JOIN CODE' }));
 
-      expect(consoleSpy).toHaveBeenCalled();
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'TOGGLE_JOIN_CODE_VISIBILITY',
+      });
     });
 
     it('does not call the onDisabledClick callback when disabled but not clicked', () => {
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
+
+      const dispatch = jest.fn();
+
       const mockOnDisabledClick = jest.fn();
 
       render(
-        <JoinCodeHider
-          isEnabled={false}
-          onDisabledClick={mockOnDisabledClick}
-        />,
+        <HostContext.Provider value={{ state, dispatch }}>
+          <JoinCodeHider
+            isEnabled={false}
+            onDisabledClick={mockOnDisabledClick}
+          />
+          ,
+        </HostContext.Provider>,
       );
 
       expect(mockOnDisabledClick).not.toHaveBeenCalled();
     });
 
     it('calls the onDisabledClick callback when disabled and clicked', () => {
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
+
+      const dispatch = jest.fn();
+
       const mockOnDisabledClick = jest.fn();
 
       render(
-        <JoinCodeHider
-          isEnabled={false}
-          onDisabledClick={mockOnDisabledClick}
-        />,
+        <HostContext.Provider value={{ state, dispatch }}>
+          <JoinCodeHider
+            isEnabled={false}
+            onDisabledClick={mockOnDisabledClick}
+          />
+          ,
+        </HostContext.Provider>,
       );
       userEvent.click(screen.getByRole('button', { name: 'HIDE JOIN CODE' }));
 
@@ -120,52 +247,112 @@ describe('JoinCodeHider', () => {
 
   describe('propTypes', () => {
     it('logs an error when attempting to render without the isEnabled Prop', () => {
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
+
+      const dispatch = jest.fn();
+
       const consoleSpy = jest
         .spyOn(console, 'error')
         .mockImplementation(() => {});
 
-      render(<JoinCodeHider onDisabledClick={() => {}} />);
+      render(
+        <HostContext.Provider value={{ state, dispatch }}>
+          <JoinCodeHider onDisabledClick={() => {}} />
+        </HostContext.Provider>,
+      );
       userEvent.click(screen.getByTestId('option-button'));
 
       expect(consoleSpy).toHaveBeenCalled();
     });
 
     it('logs an error when attempting to render the isEnabled Prop as a non bool', () => {
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
+
+      const dispatch = jest.fn();
+
       const consoleSpy = jest
         .spyOn(console, 'error')
         .mockImplementation(() => {});
 
-      render(<JoinCodeHider isEnabled="foo" onDisabledClick={() => {}} />);
+      render(
+        <HostContext.Provider value={{ state, dispatch }}>
+          <JoinCodeHider isEnabled="foo" onDisabledClick={() => {}} />
+        </HostContext.Provider>,
+      );
 
       expect(consoleSpy).toHaveBeenCalled();
     });
 
     it('logs an error when attempting to render without the onDisabledClick Prop', () => {
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
+
+      const dispatch = jest.fn();
+
       const consoleSpy = jest
         .spyOn(console, 'error')
         .mockImplementation(() => {});
 
-      render(<JoinCodeHider isEnabled />);
+      render(
+        <HostContext.Provider value={{ state, dispatch }}>
+          <JoinCodeHider isEnabled />
+        </HostContext.Provider>,
+      );
 
       expect(consoleSpy).toHaveBeenCalled();
     });
 
     it('logs an error when attempting to render the onDisabledClick Prop as a non function', () => {
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
+
+      const dispatch = jest.fn();
+
       const consoleSpy = jest
         .spyOn(console, 'error')
         .mockImplementation(() => {});
 
-      render(<JoinCodeHider isEnabled onDisabledClick="foo" />);
+      render(
+        <HostContext.Provider value={{ state, dispatch }}>
+          <JoinCodeHider isEnabled onDisabledClick="foo" />
+        </HostContext.Provider>,
+      );
 
       expect(consoleSpy).toHaveBeenCalled();
     });
 
     it('does not log an error when all required props are given correctly', () => {
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
+
+      const dispatch = jest.fn();
+
       const consoleSpy = jest
         .spyOn(console, 'error')
         .mockImplementation(() => {});
 
-      render(<JoinCodeHider isEnabled onDisabledClick={() => {}} />);
+      render(
+        <HostContext.Provider value={{ state, dispatch }}>
+          <JoinCodeHider isEnabled onDisabledClick={() => {}} />
+        </HostContext.Provider>,
+      );
 
       expect(consoleSpy).not.toHaveBeenCalled();
     });

--- a/frontend/src/components/JoinCode/JoinCode.js
+++ b/frontend/src/components/JoinCode/JoinCode.js
@@ -6,10 +6,12 @@ import LoadingIndicator from '../LoadingIndicator/LoadingIndicator';
 const propType = {
   loading: PropTypes.bool,
   code: PropTypes.string.isRequired,
+  hidden: PropTypes.bool,
 };
 
 const defaultProps = {
   loading: false,
+  hidden: false,
 };
 
 const JoinCodeComponent = styled.div`
@@ -39,12 +41,20 @@ const JoinCodeComponent = styled.div`
   }
 `;
 
-function DisplayJoinCode({ loading, code }) {
+function DisplayJoinCode({ loading, code, hidden }) {
   return (
     <JoinCodeComponent>
       <p className="join-code-title">JOIN CODE:</p>
       <div className="join-code" data-testid="join-code">
-        {loading || !code ? <LoadingIndicator secondary /> : <p>{code}</p>}
+        {
+          // TODO REMOVE NESTED TERNARY
+          // eslint-disable-next-line no-nested-ternary
+          loading || !code ? (
+            <LoadingIndicator secondary />
+          ) : !hidden ? (
+            <p>{code}</p>
+          ) : null
+        }
       </div>
     </JoinCodeComponent>
   );

--- a/frontend/src/components/JoinCode/JoinCode.js
+++ b/frontend/src/components/JoinCode/JoinCode.js
@@ -1,17 +1,16 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import LoadingIndicator from '../LoadingIndicator/LoadingIndicator';
+import { HostContext } from '../../contexts/HostContext/HostContext';
 
 const propType = {
   loading: PropTypes.bool,
   code: PropTypes.string.isRequired,
-  hidden: PropTypes.bool,
 };
 
 const defaultProps = {
   loading: false,
-  hidden: false,
 };
 
 const JoinCodeComponent = styled.div`
@@ -41,20 +40,16 @@ const JoinCodeComponent = styled.div`
   }
 `;
 
-function DisplayJoinCode({ loading, code, hidden }) {
+function DisplayJoinCode({ loading, code }) {
+  const { state } = useContext(HostContext);
+  const hidden = state.gameSettings.hideJoinCode;
+
   return (
     <JoinCodeComponent>
       <p className="join-code-title">JOIN CODE:</p>
       <div className="join-code" data-testid="join-code">
-        {
-          // TODO REMOVE NESTED TERNARY
-          // eslint-disable-next-line no-nested-ternary
-          loading || !code ? (
-            <LoadingIndicator secondary />
-          ) : !hidden ? (
-            <p>{code}</p>
-          ) : null
-        }
+        {!hidden &&
+          (loading || !code ? <LoadingIndicator secondary /> : <p>{code}</p>)}
       </div>
     </JoinCodeComponent>
   );

--- a/frontend/src/components/JoinCode/JoinCode.spec.js
+++ b/frontend/src/components/JoinCode/JoinCode.spec.js
@@ -1,28 +1,98 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import DisplayJoinCode from './JoinCode';
-
-// Can render
+import { HostContext } from '../../contexts/HostContext/HostContext';
 
 describe('joinCode', () => {
-  // ----------------------------------------------------------------------------
-  // Rendering Tests
   describe('rendering', () => {
     it('renders loading indicator when "code" is an empty string', () => {
-      render(<DisplayJoinCode code="" />);
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
+
+      const dispatch = jest.fn();
+
+      render(
+        <HostContext.Provider value={{ state, dispatch }}>
+          <DisplayJoinCode code="" />
+        </HostContext.Provider>,
+      );
       expect(screen.getByTestId('loader')).toBeInTheDocument();
       expect(screen.getByTestId('join-code')).toBeInTheDocument();
     });
 
     it('renders properly', () => {
-      render(<DisplayJoinCode code="XYA3Z" />);
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
+
+      const dispatch = jest.fn();
+
+      render(
+        <HostContext.Provider value={{ state, dispatch }}>
+          <DisplayJoinCode code="XYA3Z" />
+        </HostContext.Provider>,
+      );
+
       expect(screen.queryByTestId('loader')).not.toBeInTheDocument();
       expect(screen.getByText('XYA3Z')).toBeInTheDocument();
     });
 
     it('displays a loading indicator when loading is true', () => {
-      render(<DisplayJoinCode loading code="XYA3Z" />);
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
+
+      const dispatch = jest.fn();
+
+      render(
+        <HostContext.Provider value={{ state, dispatch }}>
+          <DisplayJoinCode loading code="XYA3Z" />
+        </HostContext.Provider>,
+      );
       expect(screen.getByTestId('loader')).toBeInTheDocument();
+      expect(screen.queryByText('XYA3Z')).not.toBeInTheDocument();
+    });
+
+    it('shows the join code when the hideJoinCode setting is false', () => {
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
+
+      const dispatch = jest.fn();
+
+      render(
+        <HostContext.Provider value={{ state, dispatch }}>
+          <DisplayJoinCode code="XYA3Z" />
+        </HostContext.Provider>,
+      );
+
+      expect(screen.queryByText('XYA3Z')).toBeInTheDocument();
+    });
+
+    it('hides the join code when the hideJoinCode setting is true', () => {
+      const state = {
+        gameSettings: {
+          hideJoinCode: true,
+        },
+      };
+
+      const dispatch = jest.fn();
+
+      render(
+        <HostContext.Provider value={{ state, dispatch }}>
+          <DisplayJoinCode code="XYA3Z" />
+        </HostContext.Provider>,
+      );
+
       expect(screen.queryByText('XYA3Z')).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/contexts/HostContext/HostContext.js
+++ b/frontend/src/contexts/HostContext/HostContext.js
@@ -24,6 +24,7 @@ const initialState = {
     selectedPacks: config.initialSelectedPack,
     handSize: config.handSize,
     winnerScreenDisplayTime: config.winnerScreenDisplayTime,
+    hideJoinCode: false,
   },
   deck: { black: [], white: [] },
   loading: [],

--- a/frontend/src/contexts/HostContext/HostReducer.js
+++ b/frontend/src/contexts/HostContext/HostReducer.js
@@ -303,6 +303,16 @@ function updateJoinCode(state, { lobbyID }) {
   };
 }
 
+function toggleJoinCode(state) {
+  return {
+    ...state,
+    gameSettings: {
+      ...state.gameSettings,
+      hideJoinCode: !state.gameSettings.hideJoinCode,
+    },
+  };
+}
+
 function HostReducer(state, action) {
   const { type, payload } = action;
 
@@ -369,6 +379,9 @@ function HostReducer(state, action) {
 
     case 'UPDATE_JOIN_CODE':
       return updateJoinCode(state, payload);
+
+    case 'TOGGLE_JOIN_CODE_VISIBILITY':
+      return toggleJoinCode(state);
 
     default:
       return { ...state };

--- a/frontend/src/contexts/HostContext/HostReducer.spec.js
+++ b/frontend/src/contexts/HostContext/HostReducer.spec.js
@@ -976,6 +976,44 @@ describe('reducer', () => {
     });
   });
 
+  describe('TOGGLE_JOIN_CODE_VISIBILITY', () => {
+    it('changes the hideJoinCode setting to false, if it is true', () => {
+      const state = {
+        gameSettings: {
+          hideJoinCode: true,
+        },
+      };
+
+      const result = HostReducer(state, {
+        type: 'TOGGLE_JOIN_CODE_VISIBILITY',
+      });
+
+      expect(result).toEqual({
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      });
+    });
+
+    it('changes the hideJoinCode setting to true, if it is false', () => {
+      const state = {
+        gameSettings: {
+          hideJoinCode: false,
+        },
+      };
+
+      const result = HostReducer(state, {
+        type: 'TOGGLE_JOIN_CODE_VISIBILITY',
+      });
+
+      expect(result).toEqual({
+        gameSettings: {
+          hideJoinCode: true,
+        },
+      });
+    });
+  });
+
   describe('PREVIEW_WINNER', () => {
     it('returns the state with updated czarSelection', () => {
       const state = {


### PR DESCRIPTION
#### 0. Make sure your issue is linked:
<!-- "closes: #issueNum". See here: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Closes #176 

#### 1. Purpose:
<!-- Give a description of what your component or submission is supposed to do/accomplish. -->
Implements functionality to the HIDE JOIN CODE button.


#### 2. Implementation:
<!-- Brief overview of your solution. -->
Adds new case for toggling join code, sets join code as not hidden by default. 


#### 3. Possible Issues:
<!-- Anything you are unsure of, specifically want others to test. -->
None seen so far. All tests pass.


#### 4. How to Test:
<!-- List all steps from pulling your branch, list any files that need to be edited and what specifically needs to be added/removed(include line #), and how to deploy it. -->
Start front and backend. Open settings and click the HIDE JOIN CODE button. Should hide the join code and change button text to SHOW JOIN CODE.

#### 5. Cleanup
- [x] I've added all TODOs needed
- [x] I've removed all unneeded comments
- [x] I've updated the snapshot tests and checked to make sure they're accurate if they changed
- [x] I've removed all unnecessary `console.log`s
