### PR TITLE
Bug 266 - Reset Czar Selection

### DIFF
--- a/frontend/src/contexts/HostContext/HostContext.js
+++ b/frontend/src/contexts/HostContext/HostContext.js
@@ -30,6 +30,7 @@ const initialState = {
   deck: { black: [], white: [] },
   loading: [],
   newPlayerStaging: [],
+  czarSelection: '',
 };
 
 export const HostContext = createContext();

--- a/frontend/src/contexts/HostContext/HostReducer.js
+++ b/frontend/src/contexts/HostContext/HostReducer.js
@@ -78,6 +78,7 @@ function dealWhiteCards(state) {
     },
     players: newPlayers,
     gameState: 'waiting-to-receive-cards',
+    czarSelection: '',
   };
 }
 

--- a/frontend/src/contexts/HostContext/HostReducer.spec.js
+++ b/frontend/src/contexts/HostContext/HostReducer.spec.js
@@ -912,6 +912,45 @@ describe('reducer', () => {
         ),
       ).toBe(true);
     });
+
+    it('resets the czar selection', () => {
+      const state = {
+        gameSettings: {
+          handSize: 5,
+        },
+        deck: {
+          white: [
+            { pack: 0, text: 'zero' },
+            { pack: 0, text: 'one' },
+            { pack: 0, text: 'two' },
+            { pack: 0, text: 'three' },
+            { pack: 0, text: 'four' },
+          ],
+          black: [{ pick: 1, pack: 0, text: 'zero' }],
+        },
+        selectedBlackCard: {
+          pick: 1,
+        },
+        playerIDs: ['foo'],
+        players: {
+          foo: {
+            cards: [
+              { pack: 0, text: 'test' },
+              { pack: 0, text: 'test' },
+              { pack: 0, text: 'test' },
+            ],
+          },
+        },
+        czarSelection: 'old-czar-selection',
+      };
+
+      const result = HostReducer(state, {
+        type: 'DEAL_WHITE_CARDS',
+        payload: {},
+      });
+
+      expect(result.czarSelection).toBe('');
+    });
   });
 
   describe('REMOVE_SUBMITTED_CARDS_FROM_PLAYER', () => {


### PR DESCRIPTION
…d empty string as initial state, add test

#### 0. Make sure your issue is linked:
<!-- "closes: #issueNum". See here: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Close #266 

#### 1. Purpose:
<!-- Give a description of what your component or submission is supposed to do/accomplish. -->

Fixes czar selection bug that caused submitted cards to show too early

#### 2. Implementation:
<!-- Brief overview of your solution. -->

reset the czar selection in state in the DEAL_WHITE_CARDS reducer action

#### 3. Possible Issues:
<!-- Anything you are unsure of, specifically want others to test. -->



#### 4. How to Test:
<!-- List all steps from pulling your branch, list any files that need to be edited and what specifically needs to be added/removed(include line #), and how to deploy it. -->

* play game
* notice how the white cards don't show up too early now

#### 5. Cleanup
- [x] I've added all TODOs needed
- [x] I've removed all unneeded comments
- [x] I've updated the snapshot tests and checked to make sure they're accurate if they changed
- [x] I've removed all unnecessary `console.log`s
