### PR TITLE
Fix bug that renders modal twice in error boundary.

### DIFF
--- a/frontend/src/errorHandlers/hostErrorHandlers/HostErrorBoundary.js
+++ b/frontend/src/errorHandlers/hostErrorHandlers/HostErrorBoundary.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import AlertModal from '../../components/Modal/AlertModal';
-import Modal from '../../components/Modal/Modal';
 
 const propTypes = {
   children: PropTypes.element,
@@ -37,9 +36,7 @@ export default class ErrorBoundary extends Component {
 
     return hasError ? (
       // render the error screen
-      <Modal onClickOutside={() => window.location.reload()}>
-        <AlertModal />
-      </Modal>
+      <AlertModal onClick={() => window.location.reload()} />
     ) : (
       // everything is okay
       children

--- a/frontend/src/errorHandlers/hostErrorHandlers/HostErrorBoundary.spec.js
+++ b/frontend/src/errorHandlers/hostErrorHandlers/HostErrorBoundary.spec.js
@@ -38,7 +38,6 @@ describe('error boundary', () => {
     );
 
     expect(screen.getByTestId('alert-modal')).toBeInTheDocument();
-    expect(screen.getByTestId('modal')).toBeInTheDocument();
   });
 
   it('renders children if an error is not thrown', async () => {
@@ -51,7 +50,6 @@ describe('error boundary', () => {
     );
 
     expect(screen.queryByTestId('alert-modal')).toBeNull();
-    expect(screen.queryByTestId('modal')).toBeNull();
     expect(screen.getByTestId('child')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
#### 0. Make sure your issue is linked:
<!-- "closes: #issueNum". See here: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

<no issue>


#### 1. Purpose:
<!-- Give a description of what your component or submission is supposed to do/accomplish. -->

The modal component was being rendered twice in the host error boundary
Remove Modal component from host error boundary

#### 2. Implementation:
<!-- Brief overview of your solution. -->

Remove the modal component in host error boundary

#### 3. Possible Issues:
<!-- Anything you are unsure of, specifically want others to test. -->



#### 4. How to Test:
<!-- List all steps from pulling your branch, list any files that need to be edited and what specifically needs to be added/removed(include line #), and how to deploy it. -->


#### 5. Cleanup
- [x] I've added all TODOs needed
- [x] I've removed all unneeded comments
- [x] I've updated the snapshot tests and checked to make sure they're accurate if they changed
- [x] I've removed all unnecessary `console.log`s
