### PR TITLE
Add host minimum window size enforcement screen

### DIFF
--- a/frontend/src/__snapshots__/App.spec.js.snap
+++ b/frontend/src/__snapshots__/App.spec.js.snap
@@ -515,6 +515,145 @@ exports[`App snapshots should initially show the welcome screen 1`] = `
 
 exports[`App snapshots should show the host screen after user has clicked the "host" button 1`] = `
 <DocumentFragment>
+  .c0 {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 100%;
+  overflow: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  z-index: 10200;
+  background-color: var(--primary-background-color);
+}
+
+@media (max-width:1920px) {
+
+}
+
+@media (max-width:1440px) {
+
+}
+
+@media (max-width:1300px) {
+
+}
+
+@media (max-width:970px) {
+
+}
+
+@media (max-width:570px) and (min-height:501px) {
+
+}
+
+@media (max-height:500px) {
+
+}
+
+@media (max-width:320px) {
+
+}
+
+@media (max-width:900px) {
+
+}
+
+@media (max-width:600px) {
+
+}
+
+@media (max-width:490px),(orientation:landscape) and (max-height:500px) {
+
+}
+
+@media (orientation:landscape) and (max-height:500px) {
+
+}
+
+@media (max-width:1920px) {
+
+}
+
+@media (max-width:1440px) {
+
+}
+
+@media (max-width:950px) {
+
+}
+
+@media (max-width:700px),(max-width:900px) and (max-height:500px) {
+
+}
+
+@media (min-width:2561px) {
+
+}
+
+@media (min-width:800px) {
+
+}
+
+@media (min-width:2000px) {
+
+}
+
+@media (min-width:3500px) {
+
+}
+
+@media only screen and (max-width:980px) {
+
+}
+
+@media (min-width:1600px) {
+
+}
+
+@media (min-width:1100px) {
+
+}
+
+@media (min-width:1600px) {
+
+}
+
+@media (min-width:3200px) {
+
+}
+
+@media (min-width:680px) and (min-height:768px) {
+  .c0 {
+    display: none;
+  }
+}
+
+<div
+    class="c0"
+  >
+    <h1>
+      Your screen size isn't big enough to host a lobby
+    </h1>
+    <p>
+      Sorry :(
+    </p>
+  </div>
   .c5 {
   display: block;
   border: 2px solid var(--primary-text-color);
@@ -1234,6 +1373,10 @@ exports[`App snapshots should show the host screen after user has clicked the "h
     margin: 0;
     padding: 0;
   }
+}
+
+@media (min-width:680px) and (min-height:768px) {
+
 }
 
 <div

--- a/frontend/src/screenControllers/HostScreenController/HostScreenController.js
+++ b/frontend/src/screenControllers/HostScreenController/HostScreenController.js
@@ -1,18 +1,40 @@
 import React, { useContext } from 'react';
+import styled from 'styled-components';
 import { HostContext } from '../../contexts/HostContext/HostContext';
 import HostPregameScreen from '../../screens/HostPregameScreen/HostPregameScreen';
 import WinnerSelectScreen from '../../screens/WinnerSelectScreen/WinnerSelectScreen';
 import HostBlackCardScreen from '../../screens/HostBlackCardScreen/HostBlackCardScreen';
 import HostRoundWinnerScreen from '../../screens/HostRoundWinnerScreen/HostRoundWinnerScreen';
 import HostGameOverScreen from '../../screens/HostGameOverScreen/HostGameOverScreen';
+import config from '../../config';
 
+const { smallDesktop } = config.breakpoint.hostBreakpoints;
 const propTypes = {};
 
-export default function HostScreenController() {
-  const {
-    state: { gameState },
-  } = useContext(HostContext);
+const ScreenTooSmall = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 100%;
+  overflow: auto;
 
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  z-index: 10200;
+
+  background-color: var(--primary-background-color);
+
+  @media (min-width: ${smallDesktop}) and (min-height: 768px) {
+    display: none;
+  }
+`;
+
+function showScreen(gameState) {
   switch (gameState) {
     case 'waiting-for-lobby':
     case 'waiting-for-players':
@@ -35,6 +57,23 @@ export default function HostScreenController() {
     default:
       throw new Error(`Unrecognized game state: ${gameState}`);
   }
+}
+
+export default function HostScreenController() {
+  const {
+    state: { gameState },
+  } = useContext(HostContext);
+
+  return (
+    <>
+      <ScreenTooSmall>
+        <h1>Your screen size isn&apos;t big enough to host a lobby</h1>
+        <p>Sorry :(</p>
+      </ScreenTooSmall>
+
+      {showScreen(gameState)}
+    </>
+  );
 }
 
 HostScreenController.propTypes = propTypes;

--- a/frontend/src/screenControllers/HostScreenController/HostScreenController.js
+++ b/frontend/src/screenControllers/HostScreenController/HostScreenController.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-curly-brace-presence */
 import React, { useContext } from 'react';
 import styled from 'styled-components';
 import { HostContext } from '../../contexts/HostContext/HostContext';
@@ -68,8 +69,8 @@ export default function HostScreenController() {
   return (
     <>
       <ScreenTooSmall>
-        <h1>Your screen size isn&apos;t big enough to host a lobby</h1>
-        <p>Sorry :(</p>
+        <h1>{`Your screen size isn't big enough to host a lobby`}</h1>
+        <p>{`Sorry :(`}</p>
       </ScreenTooSmall>
 
       {showScreen(gameState)}

--- a/frontend/src/screenControllers/HostScreenController/HostScreenController.js
+++ b/frontend/src/screenControllers/HostScreenController/HostScreenController.js
@@ -8,8 +8,9 @@ import HostRoundWinnerScreen from '../../screens/HostRoundWinnerScreen/HostRound
 import HostGameOverScreen from '../../screens/HostGameOverScreen/HostGameOverScreen';
 import config from '../../config';
 
-const { smallDesktop } = config.breakpoint.hostBreakpoints;
 const propTypes = {};
+
+const { smallDesktop } = config.breakpoint.hostBreakpoints;
 
 const ScreenTooSmall = styled.div`
   position: absolute;


### PR DESCRIPTION
#### 0. Make sure your issue is linked:
<!-- "closes: #issueNum". See here: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Close #300

#### 1. Purpose:
<!-- Give a description of what your component or submission is supposed to do/accomplish. -->
Enforce minimum host window size.


#### 2. Implementation:
<!-- Brief overview of your solution. -->
A div that has a high z-index and hides when the window is above the minimum width & height


#### 3. Possible Issues:
<!-- Anything you are unsure of, specifically want others to test. -->
It's ugly as sin but because of the z-index the background wouldn't show behind it.


#### 4. How to Test:
<!-- List all steps from pulling your branch, list any files that need to be edited and what specifically needs to be added/removed(include line #), and how to deploy it. -->
0. Start app
1. Click host
2. Resize window above and below 680x768 and verify that it tells you that your screen isn't big enough.

#### 5. Cleanup
- [x] I've added all TODOs needed
- [x] I've removed all unneeded comments
- [x] I've updated the snapshot tests and checked to make sure they're accurate if they changed
- [x] I've removed all unnecessary `console.log`s
