### PR TITLE
Hotfix/close kicked player socket

### DIFF
--- a/frontend/src/contexts/HostContext/hostReducerMiddleware.js
+++ b/frontend/src/contexts/HostContext/hostReducerMiddleware.js
@@ -101,13 +101,18 @@ function sendEndOfRoundMessages(payload) {
   });
 }
 
-function sendKickPlayerMessage(payload) {
+function sendKickPlayerMessage({ playerId }) {
   socketInstance.sendMessage({
-    recipients: [payload.playerId],
+    recipients: [playerId],
     event: 'update',
     payload: {
       gameState: 'player-kicked',
     },
+  });
+
+  socketInstance.sendMessage({
+    event: 'kick-player',
+    payload: { playerId },
   });
 }
 

--- a/frontend/src/contexts/HostContext/hostReducerMiddleware.spec.js
+++ b/frontend/src/contexts/HostContext/hostReducerMiddleware.spec.js
@@ -70,6 +70,25 @@ describe('hostReducerMiddleware', () => {
         },
       });
     });
+
+    it("calls socketInstance's sendMessage with a kick-player event and the playerId", () => {
+      const dispatch = jest.fn();
+
+      hostReducerMiddleware(
+        {
+          type: 'KICK_PLAYER',
+          payload: { playerId: 'example-player-id' },
+        },
+        dispatch,
+      );
+
+      expect(socketInstance.sendMessage).toHaveBeenCalledWith({
+        event: 'kick-player',
+        payload: {
+          playerId: 'example-player-id',
+        },
+      });
+    });
   });
 
   describe('PLAYER_CONNECTED', () => {


### PR DESCRIPTION
#### 0. Make sure your issue is linked:
<!-- "closes: #issueNum". See here: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->


#### 1. Purpose:
<!-- Give a description of what your component or submission is supposed to do/accomplish. -->
Remove/close player sockets from the lobby on player kick.


#### 2. Implementation:
<!-- Brief overview of your solution. -->
Send message to the backend on player kick that triggers the `#removePlayer` function, add test for this action as well as tests for `#removePlayer`


#### 3. Possible Issues:
<!-- Anything you are unsure of, specifically want others to test. -->



#### 4. How to Test:
<!-- List all steps from pulling your branch, list any files that need to be edited and what specifically needs to be added/removed(include line #), and how to deploy it. -->
0. Start app backend and frontend
1. Open a window and select host
2. Open another window, select join, and join the lobby you made in step 1
3. Repeat step 2 with two additional players
4. Start the game
5. Kick one of the players
6. With the remaining two players finish the round
7. Verify that the kicked player does not receive the message with the winner of the round

#### 5. Cleanup
- [x] I've added all TODOs needed
- [x] I've removed all unneeded comments
- [x] I've updated the snapshot tests and checked to make sure they're accurate if they changed
- [x] I've removed all unnecessary `console.log`s
