### PR TITLE
Fix overly aggressive minimum host window height

### DIFF
--- a/frontend/src/__snapshots__/App.spec.js.snap
+++ b/frontend/src/__snapshots__/App.spec.js.snap
@@ -616,11 +616,11 @@ exports[`App snapshots should show the host screen after user has clicked the "h
 
 }
 
-@media (min-width:) {
+@media (min-width:3200px) {
 
 }
 
-@media (min-width:680px) and (min-height:768px) {
+@media (min-width:680px) and (min-height:550px) {
   .c0 {
     display: none;
   }
@@ -1308,7 +1308,7 @@ exports[`App snapshots should show the host screen after user has clicked the "h
   }
 }
 
-@media (min-width:) {
+@media (min-width:3200px) {
   .c9 h2 {
     font-size: 4rem;
     line-height: 4.4rem;
@@ -1355,7 +1355,7 @@ exports[`App snapshots should show the host screen after user has clicked the "h
   }
 }
 
-@media (min-width:680px) and (min-height:768px) {
+@media (min-width:680px) and (min-height:550px) {
 
 }
 

--- a/frontend/src/components/HostSettingsMenu/HostSettingsMenu.js
+++ b/frontend/src/components/HostSettingsMenu/HostSettingsMenu.js
@@ -12,7 +12,7 @@ const propTypes = {
   ).isRequired,
 };
 
-const { extraLargeDesktop } = config.breakpoint.hostBreakpoints;
+const { extraLargeDesktopWidth } = config.breakpoint.hostBreakpoints;
 
 const SettingsMenu = styled.div`
   position: absolute;
@@ -58,7 +58,7 @@ const SettingsMenu = styled.div`
     }
   }
 
-  @media (min-width: ${extraLargeDesktop}) {
+  @media (min-width: ${extraLargeDesktopWidth}) {
     width: 1100px;
 
     .host-settings-header {

--- a/frontend/src/components/Modal/AlertModal.js
+++ b/frontend/src/components/Modal/AlertModal.js
@@ -19,7 +19,7 @@ const defaultProps = {
   onClick: () => window.location.reload(),
 };
 
-const { smallDesktop } = config.breakpoint.hostBreakpoints;
+const { smallDesktopWidth } = config.breakpoint.hostBreakpoints;
 
 const AlertWrapper = styled.div`
   position: absolute;
@@ -88,7 +88,7 @@ const AlertWrapper = styled.div`
     padding: 2px;
   }
 
-  @media (min-width: ${smallDesktop}) {
+  @media (min-width: ${smallDesktopWidth}) {
     max-height: 300px;
     max-width: 600px;
     width: auto;

--- a/frontend/src/components/PregameWelcomeText/PregameWelcomeText.js
+++ b/frontend/src/components/PregameWelcomeText/PregameWelcomeText.js
@@ -4,7 +4,10 @@ import styled from 'styled-components';
 import Carousel from '../Carousel/Carousel';
 import config from '../../config';
 
-const { largeDesktop, extralargeDesktop } = config.breakpoint.hostBreakpoints;
+const {
+  largeDesktopWidth,
+  extraLargeDesktopWidth,
+} = config.breakpoint.hostBreakpoints;
 
 const StyledPregameWelcomeText = styled.div`
   display: flex;
@@ -71,7 +74,7 @@ const StyledPregameWelcomeText = styled.div`
     }
   }
 
-  @media (min-width: ${largeDesktop}) {
+  @media (min-width: ${largeDesktopWidth}) {
     h2 {
       font-size: 3.2rem;
       line-height: 3.2rem;
@@ -104,7 +107,7 @@ const StyledPregameWelcomeText = styled.div`
     }
   }
 
-  @media (min-width: ${extralargeDesktop}) {
+  @media (min-width: ${extraLargeDesktopWidth}) {
     h2 {
       font-size: 4rem;
       line-height: 4.4rem;

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -21,16 +21,18 @@ const config = {
 
   breakpoint: {
     playerBreakpoints: {
-      smallMobile: '312px',
-      largeMobile: '600px',
-      smallDesktop: '1600px',
-      largeDesktop: '3200px',
+      smallMobileWidth: '312px',
+      largeMobileWidth: '600px',
+      smallDesktopWidth: '1600px',
+      largeDesktopWidth: '3200px',
     },
 
     hostBreakpoints: {
-      smallDesktop: '680px',
-      largeDesktop: '1600px',
-      extraLargeDesktop: '3200px',
+      smallDesktopWidth: '680px',
+      largeDesktopWidth: '1600px',
+      extraLargeDesktopWidth: '3200px',
+
+      smallDesktopHeight: '550px',
     },
   },
 };

--- a/frontend/src/layouts/CardHandLayout/CardHandLayout.js
+++ b/frontend/src/layouts/CardHandLayout/CardHandLayout.js
@@ -17,7 +17,7 @@ const propTypes = {
   numberSelected: PropTypes.number.isRequired,
 };
 
-const { largeMobile } = config.breakpoint.playerBreakpoints;
+const { largeMobileWidth } = config.breakpoint.playerBreakpoints;
 
 const LayoutContainer = styled.div`
   position: absolute;
@@ -43,7 +43,7 @@ const LayoutContainer = styled.div`
     flex-shrink: 0;
   }
 
-  @media (min-height: 640px) and (min-width: ${largeMobile}) {
+  @media (min-height: 640px) and (min-width: ${largeMobileWidth}) {
     .card-container {
       flex-wrap: wrap;
       justify-content: center;
@@ -91,7 +91,7 @@ const Header = styled.header`
     border: none;
   }
 
-  @media (min-height: 640px) and (min-width: ${largeMobile}) {
+  @media (min-height: 640px) and (min-width: ${largeMobileWidth}) {
     min-height: 100px;
 
     .header-txt {

--- a/frontend/src/layouts/HeaderFooterLayout/HeaderFooterLayout.js
+++ b/frontend/src/layouts/HeaderFooterLayout/HeaderFooterLayout.js
@@ -14,7 +14,7 @@ const defaultProps = {
   children: '',
 };
 
-const { largeMobile } = config.breakpoint.playerBreakpoints;
+const { largeMobileWidth } = config.breakpoint.playerBreakpoints;
 
 const Header = styled.header`
   height: min(20vh, 400px);
@@ -47,7 +47,7 @@ const Header = styled.header`
     }
   }
 
-  @media (min-width: ${largeMobile}) {
+  @media (min-width: ${largeMobileWidth}) {
     .CoC {
       margin-bottom: -8px;
       margin-bottom: max(-0.8vw, -20px);

--- a/frontend/src/layouts/HostLayout.js
+++ b/frontend/src/layouts/HostLayout.js
@@ -13,9 +13,9 @@ const propTypes = {
 };
 
 const {
-  smallDesktop,
-  largeDesktop,
-  extraLargeDesktop,
+  smallDesktopWidth,
+  largeDesktopWidth,
+  extraLargeDesktopWidth,
 } = config.breakpoint.hostBreakpoints;
 
 const HostLayoutContainer = styled.div`
@@ -70,7 +70,7 @@ const HostLayoutContainer = styled.div`
     min-width: 440px;
   }
 
-  @media (min-width: ${smallDesktop}) {
+  @media (min-width: ${smallDesktopWidth}) {
     .host-layout-header {
       height: 130px;
     }
@@ -86,7 +86,7 @@ const HostLayoutContainer = styled.div`
     }
   }
 
-  @media (min-width: ${largeDesktop}) {
+  @media (min-width: ${largeDesktopWidth}) {
     .components .left {
       min-width: 700px;
     }
@@ -98,7 +98,7 @@ const HostLayoutContainer = styled.div`
     }
   }
 
-  @media (min-width: ${extraLargeDesktop}) {
+  @media (min-width: ${extraLargeDesktopWidth}) {
     .host-layout-header {
       height: 200px;
     }

--- a/frontend/src/screenControllers/HostScreenController/HostScreenController.js
+++ b/frontend/src/screenControllers/HostScreenController/HostScreenController.js
@@ -11,7 +11,10 @@ import config from '../../config';
 
 const propTypes = {};
 
-const { smallDesktop } = config.breakpoint.hostBreakpoints;
+const {
+  smallDesktopWidth,
+  smallDesktopHeight,
+} = config.breakpoint.hostBreakpoints;
 
 const ScreenTooSmall = styled.div`
   position: absolute;
@@ -31,7 +34,7 @@ const ScreenTooSmall = styled.div`
 
   background-color: var(--primary-background-color);
 
-  @media (min-width: ${smallDesktop}) and (min-height: 768px) {
+  @media (min-width: ${smallDesktopWidth}) and (min-height: ${smallDesktopHeight}) {
     display: none;
   }
 `;

--- a/frontend/src/screens/HostPregameScreen/__snapshots__/HostPregameScreen.spec.js.snap
+++ b/frontend/src/screens/HostPregameScreen/__snapshots__/HostPregameScreen.spec.js.snap
@@ -494,7 +494,7 @@ exports[`Host Pregame Screen rendering renders 1`] = `
   }
 }
 
-@media (min-width:) {
+@media (min-width:3200px) {
   .c9 h2 {
     font-size: 4rem;
     line-height: 4.4rem;

--- a/frontend/src/screens/PlayerErrorScreen/PlayerErrorScreen.js
+++ b/frontend/src/screens/PlayerErrorScreen/PlayerErrorScreen.js
@@ -20,7 +20,10 @@ const defaultProps = {
   onClickButton: () => window.location.reload(),
 };
 
-const { largeMobile, smallDesktop } = config.breakpoint.playerBreakpoints;
+const {
+  largeMobileWidth,
+  smallDesktopWidth,
+} = config.breakpoint.playerBreakpoints;
 
 const RestartButton = styled(Button)`
   background-color: var(--primary-background-color);
@@ -30,13 +33,13 @@ const RestartButton = styled(Button)`
   border-radius: 2px;
   text-transform: uppercase;
 
-  @media screen and (min-width: ${largeMobile}) {
+  @media screen and (min-width: ${largeMobileWidth}) {
     min-width: 116px;
     height: 40px;
     margin: 40px auto 0 auto;
   }
 
-  @media screen and (min-width: ${smallDesktop}) {
+  @media screen and (min-width: ${smallDesktopWidth}) {
     font-size: 1.5rem;
     line-height: 1.5rem;
     min-width: 164px;

--- a/frontend/src/screens/PlayerJoinScreen/PlayerJoinScreen.js
+++ b/frontend/src/screens/PlayerJoinScreen/PlayerJoinScreen.js
@@ -9,9 +9,9 @@ import requestFullscreen from '../../helpers/requestFullscreen';
 const propTypes = {};
 
 const {
-  largeMobile,
-  smallDesktop,
-  largeDesktop,
+  largeMobileWidth,
+  smallDesktopWidth,
+  largeDesktopWidth,
 } = config.breakpoint.playerBreakpoints;
 
 const PlayerJoinContainer = styled.div`
@@ -70,7 +70,7 @@ const PlayerJoinContainer = styled.div`
     font-size: 1.5rem;
   }
 
-  @media screen and (min-width: ${largeMobile}) {
+  @media screen and (min-width: ${largeMobileWidth}) {
     .player-join-form-container {
       margin-top: 0;
     }
@@ -95,7 +95,7 @@ const PlayerJoinContainer = styled.div`
     }
   }
 
-  @media screen and (min-width: ${smallDesktop}) {
+  @media screen and (min-width: ${smallDesktopWidth}) {
     input,
     input::placeholder {
       font-size: 2.5rem;
@@ -105,7 +105,7 @@ const PlayerJoinContainer = styled.div`
     }
   }
 
-  @media (min-width: ${largeDesktop}) {
+  @media (min-width: ${largeDesktopWidth}) {
     input,
     input::placeholder {
       font-size: 3rem;
@@ -116,7 +116,7 @@ const PlayerJoinContainer = styled.div`
   }
 
   // mobile landscape orientation
-  @media screen and (max-height: 567px) and (min-width: ${largeMobile}) {
+  @media screen and (max-height: 567px) and (min-width: ${largeMobileWidth}) {
     .player-join-form-container {
       margin-top: 0;
     }
@@ -149,27 +149,27 @@ const PlayerJoinButton = styled(Button)`
   text-transform: uppercase;
   margin-top: 50px;
 
-  @media screen and (min-width: ${largeMobile}) {
+  @media screen and (min-width: ${largeMobileWidth}) {
     font-size: 1.5rem;
     width: 256px;
     height: 66px;
     margin-top: 100px;
   }
 
-  @media screen and (min-width: ${smallDesktop}) {
+  @media screen and (min-width: ${smallDesktopWidth}) {
     font-size: 2.25rem;
     width: 350px;
     height: 82px;
   }
 
-  @media (min-width: ${largeDesktop}) {
+  @media (min-width: ${largeDesktopWidth}) {
     width: 490px;
     height: 126px;
 
     font-size: 3rem;
   }
 
-  @media screen and (max-height: 567px) and (min-width: ${largeMobile}) {
+  @media screen and (max-height: 567px) and (min-width: ${largeMobileWidth}) {
     margin-top: 30px;
   }
 `;

--- a/frontend/src/screens/PlayerMessageScreen/PlayerMessageScreen.js
+++ b/frontend/src/screens/PlayerMessageScreen/PlayerMessageScreen.js
@@ -17,7 +17,10 @@ const defaultProps = {
   children: null,
 };
 
-const { largeMobile, smallDesktop } = config.breakpoint.playerBreakpoints;
+const {
+  largeMobileWidth,
+  smallDesktopWidth,
+} = config.breakpoint.playerBreakpoints;
 
 const PlayerMessageScreenWrapper = styled.div`
   position: fixed;
@@ -42,22 +45,22 @@ const PlayerMessageScreenWrapper = styled.div`
   .big-text {
     font-weight: 900;
     font-size: 2rem;
-    @media (min-width: ${largeMobile}) {
+    @media (min-width: ${largeMobileWidth}) {
       font-size: 3rem;
     }
 
-    @media (min-width: ${smallDesktop}) {
+    @media (min-width: ${smallDesktopWidth}) {
       font-size: 5rem;
     }
   }
 
   .small-text {
     font-size: 1rem;
-    @media (min-width: ${largeMobile}) {
+    @media (min-width: ${largeMobileWidth}) {
       font-size: 1.5rem;
     }
 
-    @media (min-width: ${smallDesktop}) {
+    @media (min-width: ${smallDesktopWidth}) {
       font-size: 2rem;
     }
   }

--- a/frontend/src/screens/WelcomeScreen/WelcomeScreen.js
+++ b/frontend/src/screens/WelcomeScreen/WelcomeScreen.js
@@ -11,8 +11,11 @@ const propTypes = {
   handleHostClick: PropTypes.func.isRequired,
 };
 
-const { smallDesktop, largeDesktop } = config.breakpoint.playerBreakpoints;
-const smallHostBreakpoint = config.breakpoint.hostBreakpoints.smallDesktop;
+const {
+  smallDesktopWidth,
+  largeDesktopWidth,
+} = config.breakpoint.playerBreakpoints;
+const smallHostBreakpoint = config.breakpoint.hostBreakpoints.smallDesktopWidth;
 
 const WelcomeScreenWrapper = styled.div`
   display: flex;
@@ -155,7 +158,7 @@ const WelcomeScreenWrapper = styled.div`
     }
   }
 
-  @media (min-width: ${smallDesktop}) {
+  @media (min-width: ${smallDesktopWidth}) {
     .definition-container {
       font-size: 5.2rem;
       font-weight: 700;
@@ -186,7 +189,7 @@ const WelcomeScreenWrapper = styled.div`
   }
 
   /* Screens above 1440p */
-  @media (min-width: ${largeDesktop}) {
+  @media (min-width: ${largeDesktopWidth}) {
     .definition-container {
       font-size: 6.5rem;
       line-height: 4.8rem;


### PR DESCRIPTION
Add minimum window height as option in config file. Update other window size breakpoint descriptions to accompany this change.

#### 0. Make sure your issue is linked:
<!-- "closes: #issueNum". See here: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->


#### 1. Purpose:
<!-- Give a description of what your component or submission is supposed to do/accomplish. -->
Reduce the minimum host window height requirement.


#### 2. Implementation:
<!-- Brief overview of your solution. -->
Add config option for smallDesktopHeight at 550px which seems to be the minimum height at which the host screen looks right.


#### 3. Possible Issues:
<!-- Anything you are unsure of, specifically want others to test. -->
At some combination of width and new min height some components of the host screen overflow, not sure how to approach this. In my research to establish minimum screen sizes it was decided that we would not support hotdog style monitor splitting of host screens at small resolutions. I am not sure how to enforce this or if we need to.


#### 4. How to Test:
<!-- List all steps from pulling your branch, list any files that need to be edited and what specifically needs to be added/removed(include line #), and how to deploy it. -->
0. Start app backend and frontend
1. Open a window and select host
2. Play with the resolutions of this host screen using the dev tools and check that at near the minimum supported window size things look good.

#### 5. Cleanup
- [x] I've added all TODOs needed
- [x] I've removed all unneeded comments
- [x] I've updated the snapshot tests and checked to make sure they're accurate if they changed
- [x] I've removed all unnecessary `console.log`s
